### PR TITLE
add threaded sum search

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -340,9 +340,9 @@ fn boyer_moore_magiclen(haystack: &str, needle: &str) -> bool {
 }
 
 fn threaded_sum_search(haystack: &str, needle: &str) -> bool {
-    const TOTAL_MIN_LEN_HEURISTIC: usize = 1024;
+    const MIN_LEN_HEURISTIC: usize = 1024;
 
-    if haystack.len() < TOTAL_MIN_LEN_HEURISTIC {
+    if haystack.len() < MIN_LEN_HEURISTIC {
         sum_search(haystack, needle)
     } else {
         let haystack: Arc<str> = Arc::from(haystack);


### PR DESCRIPTION
This PR adds an initial implementation of a parallel substring search based on `sum_search`  . Of course, there is room for improvement, but I will leave it like this  for now.

EDIT: for reference, this is the performance on my machine:
```
std_search = 232.46µs
naive_search = 7.92ms
sum_search = 2.95ms
bit_shift_search = 4.31ms
sum_search_bad = 4.28ms
xor_search = 4.23ms
needle = 4.87ms
sum_3 = 12.75ms
boyer-moore-magiclen = 4.26ms
threaded-sum-search = 1.34ms
```